### PR TITLE
Include ./vendor/node_modules in NODE_PATH

### DIFF
--- a/lib/stylus.rb
+++ b/lib/stylus.rb
@@ -154,5 +154,5 @@ module Stylus
 
   # Exports the `.node_modules` folder on the working directory so npm can
   # require modules installed locally.
-  ENV['NODE_PATH'] = "#{File.expand_path('node_modules')}:#{bundled_path}:#{ENV['NODE_PATH']}"
+  ENV['NODE_PATH'] = "#{File.expand_path('node_modules')}:#{File.expand_path('vendor/node_modules')}:#{bundled_path}:#{ENV['NODE_PATH']}"
 end


### PR DESCRIPTION
Added `./vendor/node_modules` to `NODE_PATH` var just in case one wanted to shift it into the `./vendor` dir for reasons of consistency w/ rails conventions (dumb little thing, I realize that).
