### PR TITLE
Restrict import processor to .styl files

### DIFF
--- a/lib/stylus/import_processor.rb
+++ b/lib/stylus/import_processor.rb
@@ -33,7 +33,7 @@ module Stylus
     # Internal: Returns true if the file being processed counts as a
     # Stylus file (That is, it has a .styl extension).
     def stylus_file?(context)
-      context.environment.attributes_for(file).extensions.include?('.styl')
+      File.fnmatch('*.styl', file) || File.fnmatch('*.styl.*', file)
     end
 
     # Internal: Scan the stylesheet body, looking for '@import' calls to

--- a/spec/import_processor_spec.rb
+++ b/spec/import_processor_spec.rb
@@ -49,7 +49,6 @@ describe Stylus::ImportProcessor do
     template = Stylus::ImportProcessor.new('stylesheet.scss') { source }
     context = double
 
-    expect(context).to receive(:environment).and_return(env)
     expect(context).to_not receive(:depend_on)
     template.render(context)
   end


### PR DESCRIPTION
Currently, ruby-stylus doesn't interact well with files that have the same syntax for `@import`s, but aren't stylus files, such as SASS files. In some cases, this can cause really nasty side effects - we sometimes saw endless loops processing our legacy SASS templates that led to the Stylus code.

This change should restrict the @import directive processor to .styl files, and really helps us smoothly transition our stylesheets over. I hope you'll consider it for inclusion! (-:
