### PR TITLE
Prevent exception by no extension logical_path

### DIFF
--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -36,7 +36,7 @@ asset-path(key)
       # Returns string representations of hash in Stylus syntax
       def assets_hash(scope)
         @assets_hash ||= scope.environment.each_logical_path.each_with_object({ :url => '', :path => '' }) do |logical_path, assets_hash|
-          unless logical_path =~/.*\.(css|js)$/
+          unless File.extname(logical_path) =~ /^(\.(css|js)|)$/
             path_to_asset = scope.path_to_asset(logical_path)
             assets_hash[:url] << "('#{logical_path}' url(\"#{path_to_asset}\")) "
             assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "


### PR DESCRIPTION
Hi @lucasmazza

Thank you for very nice library. Stylus is so comfortable for me ;)

I use ruby-stylus and newest sprockets (2.10.1) with bower in Rails4.

When I use some packages which are installed via bower, then I got error **"Asset logical path has no extension xxx/xxx"** against some files like `README` or `LICENSE` at development server process and `assets:precompile` phase.
This error will be raised at initialization of [Sprockets::Asset](https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/asset.rb#L36) class.

My third-party packages are in `vendor/assets/components`. And I use these packages with `require` directive via bower.json support of sprockets in application.css and application.js.

The ruby-stylus seems to add all files (currently without `css|js`) from `config.assets.paths` of rails into `assets_hash`.
This commit ignores these no extension files also. It works for me.

What do you think about it ?. (Do you know any other solutions ?)
# This seems to be related sprocket's [issue #347](https://github.com/sstephenson/sprockets/issues/347).

This is my [environment and trace](https://gist.github.com/grauwoelfchen/8646077).
