### PR TITLE
Add an define method to access stylus' define javascript api.

### DIFF
--- a/lib/stylus.rb
+++ b/lib/stylus.rb
@@ -27,7 +27,7 @@ module Stylus
     @@debug     = false
     @@paths     = []
     @@imports   = []
-    @@api_calls = {}
+    @@definitions = {}
     @@plugins   = {}
 
     # Stores a list of plugins to import inside `Stylus`, with an optional hash.
@@ -49,9 +49,10 @@ module Stylus
     alias :imports :import
 
 
-    # Stores a list of api calls to execute on every compile process.
-    def api(command, *args)
-      @@api_calls[command] = args
+    # Stores a list of defined variables to create on every compile process.
+    def define(variable, value, options = {})
+      literal = true if options[:literal]
+      @@definitions[variable] = { value: value, literal: literal }
     end
 
     # Retrieves all the registered plugins.
@@ -59,9 +60,9 @@ module Stylus
       @@plugins
     end
 
-    # Retrieves all the registered api calls.
-    def api_calls
-      @@api_calls
+    # Retrieves all the registered variables.
+    def definitions
+      @@definitions
     end
 
     # Returns the global load path `Array` for your stylesheets.
@@ -115,7 +116,7 @@ module Stylus
       end
       source  = source.read if source.respond_to?(:read)
       options = merge_options(options)
-      exec('compile', source, options, plugins, imports, api_calls)
+      exec('compile', source, options, plugins, imports, definitions)
     end
 
     # Converts back an input of plain CSS to the `Stylus` syntax. The source object can be

--- a/lib/stylus/runtime/compiler.js
+++ b/lib/stylus/runtime/compiler.js
@@ -1,6 +1,6 @@
 var stylus = require('stylus');
 
-function compile(str, options, plugins, imports, apiCalls) {
+function compile(str, options, plugins, imports, definitions) {
   var style = stylus(str, options);
   var output = '';
 
@@ -13,8 +13,15 @@ function compile(str, options, plugins, imports, apiCalls) {
     style.import(path);
   })
 
-  for(var command in apiCalls) {
-    style[command].apply(style, apiCalls[command]);
+  for(var definition in definitions) {
+    obj = definitions[definition];
+    value = obj.value
+
+    if(obj.literal) {
+      value = new stylus.nodes.Literal(value);
+    }
+
+    style.define(definition, value);
   }
 
   style.render(function(error, css) {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ RSpec.configure do |config|
     Stylus.debug = false
     Stylus.paths = []
     Stylus.plugins.clear
-    Stylus.api_calls.clear
+    Stylus.definitions.clear
     Stylus.imports.clear
   end
 end

--- a/spec/stylesheets/api_call.styl
+++ b/spec/stylesheets/api_call.styl
@@ -1,2 +1,0 @@
-body
-  color: mycolor

--- a/spec/stylesheets/definition.styl
+++ b/spec/stylesheets/definition.styl
@@ -1,0 +1,2 @@
+body
+  content: mystring

--- a/spec/stylus_spec.rb
+++ b/spec/stylus_spec.rb
@@ -62,15 +62,21 @@ describe Stylus do
     expect(Stylus.compile(input)).to eq(output)
   end
 
-  it 'stores the api calls' do
-    Stylus.api "define", "mycolor", "red"
-    expect(Stylus).to have(1).api_calls
+  it 'stores the define calls' do
+    Stylus.define "mystring", "test"
+    expect(Stylus).to have(1).definitions
   end
 
-  it 'executes the given api call' do
-    Stylus.api "define", "mycolor", "red"
-    input, output = fixture(:api_call)
-    expect(Stylus.compile(input)).to match(/color: 'red'/)
+  it 'defines a global variable string' do
+    Stylus.define "mystring", "test"
+    input, output = fixture(:definition)
+    expect(Stylus.compile(input)).to match(/content: 'test'/)
+  end
+
+  it 'defines a global variable literal' do
+    Stylus.define "mystring", "red", :literal => true
+    input, output = fixture(:definition)
+    expect(Stylus.compile(input)).to match(/content: red/)
   end
 
   it 'includes and imports "nib" automatically' do


### PR DESCRIPTION
I needed this method to create variables for custom theming. It's essentially just a simple wrapper that shells out to the define function on the stylus object. Works as a class method on Stylus, e.g:

`Stylus.define "mycolor", "red"`

which uses the `define` api to create a `mycolor` global variable.  Also takes a :literal option in case you need to define CSS keywords.

Also included some passing tests.  I'd like to see this in the next ruby-stylus version in some form or another, so let me know what you think!
