### PR TITLE
Include all assets in assets hash

### DIFF
--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -36,11 +36,9 @@ asset-path(key)
       # Returns string representations of hash in Stylus syntax
       def assets_hash(scope)
         @assets_hash ||= scope.environment.each_logical_path.each_with_object({ :url => '', :path => '' }) do |logical_path, assets_hash|
-          unless File.extname(logical_path) =~ /^(\.(css|js)|)$/
-            path_to_asset = scope.path_to_asset(logical_path)
-            assets_hash[:url] << "('#{logical_path}' url(\"#{path_to_asset}\")) "
-            assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "
-          end
+          path_to_asset = scope.path_to_asset(logical_path)
+          assets_hash[:url] << "('#{logical_path}' url(\"#{path_to_asset}\")) "
+          assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "
         end
       end
 


### PR DESCRIPTION
Now assets like webfonts are excluded from assets hash and thus unable to link through provided functions.
