### PR TITLE
Add excluded extensions to assets_hash to avoid runtime errors. Fix 73.

### DIFF
--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -3,7 +3,7 @@ require 'stylus/tilt/stylus'
 module Stylus
   module Rails
     class StylusTemplate < ::Tilt::StylusTemplate
-      EXCLUDED_EXTENSIONS = %w{ css js gzip json md }
+      EXCLUDED_EXTENSIONS = %w{ css js gzip json md html }
 
       # Public: The default mime type for stylesheets.
       self.default_mime_type = 'text/css'

--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -3,6 +3,7 @@ require 'stylus/tilt/stylus'
 module Stylus
   module Rails
     class StylusTemplate < ::Tilt::StylusTemplate
+      EXCLUDED_EXTENSIONS = %w{ css js gzip json md }
 
       # Public: The default mime type for stylesheets.
       self.default_mime_type = 'text/css'
@@ -36,7 +37,8 @@ asset-path(key)
       # Returns string representations of hash in Stylus syntax
       def assets_hash(scope)
         @assets_hash ||= scope.environment.each_logical_path.each_with_object({ :url => '', :path => '' }) do |logical_path, assets_hash|
-          unless File.extname(logical_path) =~ /^(\.(css|js)|)$/
+          extensions = EXCLUDED_EXTENSIONS.join('|')
+          unless File.extname(logical_path) =~ Regexp.new("^(\.(#{extensions})|)$")
             path_to_asset = scope.path_to_asset(logical_path)
             assets_hash[:url] << "('#{logical_path}' url(\"#{path_to_asset}\")) "
             assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "


### PR DESCRIPTION
I added some excluded extensions when building the `assets_hash`.
This fixes #73.

A whitelist approach could possibly be better than a blacklist approach
when building the hash, though. Do you have any opinion on this?