### PR TITLE
Asset whitelist, Sprockets 3 compatibility.

### DIFF
--- a/lib/stylus.rb
+++ b/lib/stylus.rb
@@ -22,13 +22,37 @@ require 'stylus/railtie' if defined?(::Rails)
 #
 module Stylus
   extend Runtime
+
+  class Configuration
+    attr_accessor :assets_whitelist
+
+    def initialize
+      @assets_whitelist = /\.           # Extension starts with a literal 'dot'.
+          (?:(png|jpe?g|gif|svg|webp))  # Match importable images.
+        | (?:(ttf|eot|woff))            # Match font formats (svg already matched above).
+        | (?:(mp4|webm|ogg))            # Match HTML5 video formats.
+        | (?:(styl))                    # Force a dependency on other Stylus files, or imports break.
+      \z/x
+    end
+  end
+
   class << self
+    attr_writer :configuration
+
     @@compress  = false
     @@debug     = false
     @@paths     = []
     @@imports   = []
     @@definitions = {}
     @@plugins   = {}
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
 
     # Stores a list of plugins to import inside `Stylus`, with an optional hash.
     def use(*options)

--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -6,6 +6,7 @@ module Stylus
       VALID_ASSETS = /\.                # Extension starts with a literal 'dot'.
           (?:(png|jpe?g|gif|svg|webp))  # Match importable images.
         | (?:(ttf|eot|woff))            # Match font formats (svg already matched above).
+        | (?:(styl))                    # Force a dependency on other Stylus files, or imports break.
       \Z/x.freeze
 
       # Public: The default mime type for stylesheets.

--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -3,12 +3,6 @@ require 'stylus/tilt/stylus'
 module Stylus
   module Rails
     class StylusTemplate < ::Tilt::StylusTemplate
-      VALID_ASSETS = /\.                # Extension starts with a literal 'dot'.
-          (?:(png|jpe?g|gif|svg|webp))  # Match importable images.
-        | (?:(ttf|eot|woff))            # Match font formats (svg already matched above).
-        | (?:(styl))                    # Force a dependency on other Stylus files, or imports break.
-      \Z/x.freeze
-
       # Public: The default mime type for stylesheets.
       self.default_mime_type = 'text/css'
 
@@ -40,9 +34,10 @@ asset-path(key)
       #
       # Returns string representations of hash in Stylus syntax
       def assets_hash(scope)
-        @assets_hash ||= scope.environment.each_logical_path.each_with_object(url: '', path: '') do |logical_path, assets_hash|
-          next unless File.extname(logical_path) =~ VALID_ASSETS
-          path_to_asset = scope.path_to_asset(logical_path)
+        @assets_hash ||= scope.environment.logical_paths.each_with_object(url: '', path: '') do |logical_path, assets_hash|
+          logical_path = logical_path[0]
+          next unless File.extname(logical_path) =~ Stylus.configuration.assets_whitelist
+          path_to_asset = scope.asset_url(logical_path)
           assets_hash[:url] << "('#{logical_path}' url(\"#{path_to_asset}\")) "
           assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "
         end

--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -3,6 +3,10 @@ require 'stylus/tilt/stylus'
 module Stylus
   module Rails
     class StylusTemplate < ::Tilt::StylusTemplate
+      VALID_ASSETS = /\.                # Extension starts with a literal 'dot'.
+          (?:(png|jpe?g|gif|svg|webp))  # Match importable images.
+        | (?:(ttf|eot|woff))            # Match font formats (svg already matched above).
+      \Z/x.freeze
 
       # Public: The default mime type for stylesheets.
       self.default_mime_type = 'text/css'
@@ -35,15 +39,13 @@ asset-path(key)
       #
       # Returns string representations of hash in Stylus syntax
       def assets_hash(scope)
-        @assets_hash ||= scope.environment.each_logical_path.each_with_object({ :url => '', :path => '' }) do |logical_path, assets_hash|
-          unless File.extname(logical_path) =~ /^(\.(css|js)|)$/
-            path_to_asset = scope.path_to_asset(logical_path)
-            assets_hash[:url] << "('#{logical_path}' url(\"#{path_to_asset}\")) "
-            assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "
-          end
+        @assets_hash ||= scope.environment.each_logical_path.each_with_object(url: '', path: '') do |logical_path, assets_hash|
+          next unless File.extname(logical_path) =~ VALID_ASSETS
+          path_to_asset = scope.path_to_asset(logical_path)
+          assets_hash[:url] = "('#{logical_path}' url(\"#{path_to_asset}\")) "
+          assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "
         end
       end
-
     end
   end
 end

--- a/lib/stylus/tilt/rails.rb
+++ b/lib/stylus/tilt/rails.rb
@@ -42,7 +42,7 @@ asset-path(key)
         @assets_hash ||= scope.environment.each_logical_path.each_with_object(url: '', path: '') do |logical_path, assets_hash|
           next unless File.extname(logical_path) =~ VALID_ASSETS
           path_to_asset = scope.path_to_asset(logical_path)
-          assets_hash[:url] = "('#{logical_path}' url(\"#{path_to_asset}\")) "
+          assets_hash[:url] << "('#{logical_path}' url(\"#{path_to_asset}\")) "
           assets_hash[:path] << "('#{logical_path}' \"#{path_to_asset}\") "
         end
       end


### PR DESCRIPTION
This PR combines a couple of fixes: one to whitelist specific file extensions---or, really, files matching any regular expression, as it's meant to be user-configurable---and one to make the gem's asset-finding logic compatible with Sprockets 3.

Incidentally, if you're looking for volunteers to help maintain the gem in the future, I'd be happy to throw my hat in the ring. My e-mail address is in my GitHub profile if you'd like to chat about it directly. I'd hate to see this gem languish, if only for the selfish reason that I'd like to keep using it, and I have some ideas for improving it---adding tests, making that `Configuration` object idiom standard, etc.