### PR TITLE
[spec] Fix problems with trailing newlines for compressed output

### DIFF
--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -35,6 +35,7 @@ describe 'Rails integration' do
 
   it 'compress the output if Rails is configured to compress them too' do
     result = fixture(:compressed).last
+    result.rstrip!  # because of modern text editors automatically adding new lines at the end of file
 
     app = create_app(:compress => true)
     app.assets['compressed'].to_s.should == result

--- a/spec/stylus_spec.rb
+++ b/spec/stylus_spec.rb
@@ -14,12 +14,14 @@ describe Stylus do
 
   it 'compress the file when the "compress" flag is given' do
     input, output = fixture(:compressed)
+    output.rstrip! # because of modern text editors automatically adding new lines at the end of file
     expect(Stylus.compile(input, compress: true)).to eq(output)
   end
 
   it 'handles the compress flag globally' do
     Stylus.compress = true
     input, output = fixture(:compressed)
+    output.rstrip! # because of modern text editors automatically adding new lines at the end of file
     expect(Stylus.compile(input)).to eq(output)
   end
 

--- a/spec/tilt/stylus_spec.rb
+++ b/spec/tilt/stylus_spec.rb
@@ -19,6 +19,7 @@ describe Tilt::StylusTemplate do
   it 'compiles with the compress option' do
     input, output = fixture(:compressed)
     template = Tilt::StylusTemplate.new(compress: true) { |_| input }
+    output.rstrip!  # because of modern text editors automatically adding new lines at the end of file
     expect(template.render).to eq(output)
   end
 end


### PR DESCRIPTION
I tried running specs on my machine (Mac 10.10.3) and specs for compressed output didn't work well. So I fixed them :)