### PR TITLE
Add support for defines with hash values

### DIFF
--- a/lib/stylus/runtime/compiler.js
+++ b/lib/stylus/runtime/compiler.js
@@ -17,11 +17,14 @@ function compile(str, options, plugins, imports, definitions) {
     obj = definitions[definition];
     value = obj.value
 
-    if(obj.literal) {
-      value = new stylus.nodes.Literal(value);
+    if (typeof value == 'object') {
+      style.define(definition, value, true);
+    } else {
+      if(obj.literal == true) {
+        value = new stylus.nodes.Literal(value);
+      }
+      style.define(definition, value);
     }
-
-    style.define(definition, value);
   }
 
   style.render(function(error, css) {

--- a/spec/stylesheets/definition_hash.styl
+++ b/spec/stylesheets/definition_hash.styl
@@ -1,0 +1,8 @@
+
+p
+  text-align my_obj['text_align']
+
+if my_obj.if_cond
+  indent = my_obj['text_indent']
+  div
+    text-indent unquote(indent)

--- a/spec/stylus_spec.rb
+++ b/spec/stylus_spec.rb
@@ -79,6 +79,36 @@ describe Stylus do
     expect(Stylus.compile(input)).to match(/content: red/)
   end
 
+  it 'defines a hash variable' do
+    obj = {
+        :text_indent => '10px',
+        :text_align => 10,
+        :if_cond => true,
+    }
+    Stylus.define :my_obj, obj
+
+    input, _output = fixture(:definition_hash)
+
+    compiled = Stylus.compile(input)
+    expect(compiled).to match(/text-indent: 10px/)
+    expect(compiled).to match(/text-align: 10\b/)
+  end
+
+  it 'defines a hash variable and supports if' do
+    obj = {
+        :text_indent => '20px',
+        :text_align => 20,
+        :if_cond => false,
+    }
+    Stylus.define :my_obj, obj
+
+    input, _output = fixture(:definition_hash)
+
+    compiled = Stylus.compile(input)
+    expect(compiled).to_not match(/text-indent: 20px\b/)
+    expect(compiled).to match(/text-align: 20\b/)
+  end
+
   it 'includes and imports "nib" automatically' do
     Stylus.nib = true
     input, output = fixture(:nib)


### PR DESCRIPTION
When you pass hash into `define`, stylus will convert it into list or whatever it is.

Example: `{ :key => 'value' }` becomes `((key 'value'))`
This just doesn't make sense.

So I add support for hash values. Usage is not so nice as I expect, but it works.